### PR TITLE
Fix level up add to user balance

### DIFF
--- a/packages/mrwhale-discord/src/client/managers/level-manager.ts
+++ b/packages/mrwhale-discord/src/client/managers/level-manager.ts
@@ -280,6 +280,6 @@ export class LevelManager {
 
     this.increaseExp(message, userId, guildId, expGained);
 
-    await this.bot.addToUserBalance(message, guildId, gemsGained);
+    await this.bot.addToUserBalance(message, userId, gemsGained);
   }
 }


### PR DESCRIPTION
When the user levels up the bot rewards gems to the user's balance. However in the event listener the guild id was being passed into `addToUserBalance` instead of the user id.