### PR TITLE
Add commands for managing weekly game jams

### DIFF
--- a/packages/mrwhale-discord/src/client/discord-bot-client.ts
+++ b/packages/mrwhale-discord/src/client/discord-bot-client.ts
@@ -59,6 +59,7 @@ import { ActivitySchedulerManager } from "./managers/activity-scheduler-manager"
 import { TreasureHuntManager } from "./managers/treasure-hunt-manager";
 import { Activities } from "../types/activities/activities";
 import { NotificationManager } from "./managers/notification-manager";
+import { JamManager } from "./managers/jam-manager";
 
 const { on, once, registerListeners } = ListenerDecorators;
 
@@ -193,6 +194,13 @@ export class DiscordBotClient extends BotClient<DiscordCommand> {
   }
 
   /**
+   * Gets the instance of the JamManager.
+   */
+  get jamManager(): JamManager {
+    return this._jamManager;
+  }
+
+  /**
    * The discord bot list API key.
    */
   private discordBotList?: string;
@@ -214,6 +222,7 @@ export class DiscordBotClient extends BotClient<DiscordCommand> {
   private _fishingAttemptTracker: FishingAttemptTracker;
   private _fishSpawner: FishSpawner;
   private _notificationManager: NotificationManager;
+  private _jamManager: JamManager;
 
   constructor(botOptions: DiscordBotOptions, clientOptions: ClientOptions) {
     super(botOptions);
@@ -678,6 +687,8 @@ export class DiscordBotClient extends BotClient<DiscordCommand> {
     this.userBalanceManager = new UserBalanceManager();
     this.greetingsManager = new GreetingsManager(this);
     this._treasureHuntManager = new TreasureHuntManager(this);
+    this._jamManager = new JamManager(this);
+    this._jamManager.start().catch((e) => this.logger.error("JamManager failed to start:", e));
   }
 
   private initialiseHandlers(): void {

--- a/packages/mrwhale-discord/src/client/managers/jam-manager.ts
+++ b/packages/mrwhale-discord/src/client/managers/jam-manager.ts
@@ -1,0 +1,574 @@
+import {
+  EmbedBuilder,
+  Guild,
+  GuildScheduledEventEntityType,
+  GuildScheduledEventPrivacyLevel,
+  GuildTextBasedChannel,
+  TextChannel,
+} from "discord.js";
+
+import { DiscordBotClient } from "../discord-bot-client";
+import { Jam, JamInstance } from "../../database/models/jam";
+import {
+  JamSubmission,
+  JamSubmissionInstance,
+} from "../../database/models/jam-submission";
+import {
+  JAM_ANNOUNCEMENT_INTROS,
+  JAM_CLOSE_INTROS,
+  DAILY_PROMPTS,
+  getRandomJamElement,
+  getNextTheme,
+} from "../../data/jam-data";
+import { Settings } from "../../types/settings";
+import { EMBED_COLOR } from "../../constants";
+
+const JAM_DURATION_DAYS = 7;
+const JAM_DURATION_HOURS = JAM_DURATION_DAYS * 24;
+const JAM_CHECK_INTERVAL_MS = 60 * 60 * 1000; // Check every hour
+const JAM_START_DAY = 0; // Sunday (0 = Sunday in JS Date)
+const JAM_START_HOUR_UTC = 12; // Noon UTC
+
+/**
+ * Manages the weekly game jam lifecycle: creation, daily prompts, closing, and winner announcement.
+ */
+export class JamManager {
+  private checkIntervalId: NodeJS.Timeout | null = null;
+
+  constructor(private bot: DiscordBotClient) {}
+
+  /**
+   * Starts the hourly check loop for all guilds.
+   * Should be called once the bot is ready.
+   */
+  async start(): Promise<void> {
+    // Ensure tables exist (safe to call on every startup with alter: true)
+    await Jam.sync({ alter: true });
+    await JamSubmission.sync({ alter: true });
+
+    this.runCheck();
+    this.checkIntervalId = setInterval(
+      () => this.runCheck(),
+      JAM_CHECK_INTERVAL_MS,
+    );
+  }
+
+  /**
+   * Stops the check loop.
+   */
+  stop(): void {
+    if (this.checkIntervalId) {
+      clearInterval(this.checkIntervalId);
+      this.checkIntervalId = null;
+    }
+  }
+
+  /**
+   * Gets the currently active jam for a guild, or null if none.
+   * @param guildId The ID of the guild to retrieve the active jam for.
+   * @returns The active jam instance, or null if none exist.
+   */
+  async getCurrentJam(guildId: string): Promise<JamInstance | null> {
+    return Jam.findOne({
+      where: { guildId, status: "active" },
+      order: [["startDate", "DESC"]],
+    });
+  }
+
+  /**
+   * Gets all closed jams for a guild, ordered by most recent first.
+   * Returns an empty array if none exist.
+   * @param guildId The ID of the guild to retrieve past jams for.
+   * @param limit The maximum number of past jams to retrieve (default: 10).
+   * @returns An array of past jam instances.
+   */
+  async getPastJams(guildId: string, limit = 10): Promise<JamInstance[]> {
+    return Jam.findAll({
+      where: { guildId, status: "closed" },
+      order: [["endDate", "DESC"]],
+      limit,
+    });
+  }
+
+  /**
+   * Gets all submissions for a given jam.
+   * Returns an empty array if no submissions exist.
+   * @param jamId The ID of the jam to retrieve submissions for.
+   * @returns An array of jam submission instances.
+   */
+  async getSubmissions(jamId: number): Promise<JamSubmissionInstance[]> {
+    return JamSubmission.findAll({
+      where: { jamId },
+      order: [["submittedAt", "ASC"]],
+    });
+  }
+
+  /**
+   * Creates a jam immediately for a guild.
+   * Useful for testing or when an automatic Sunday run was missed.
+   *
+   * @param guildId The ID of the guild to create the jam in.
+   * @param durationHours The duration of the jam in hours (default: 168 hours = 7 days).
+   * @returns An object indicating success or failure, and the jam if successful.
+   */
+  async createJamNow(
+    guildId: string,
+    durationHours: number = JAM_DURATION_HOURS,
+  ): Promise<{ success: boolean; error?: string; jam?: JamInstance }> {
+    const guild = this.bot.client.guilds.cache.get(guildId);
+    if (!guild) {
+      return { success: false, error: "Guild not found." };
+    }
+
+    const activeJam = await this.getCurrentJam(guildId);
+    if (activeJam) {
+      return {
+        success: false,
+        error: `A jam is already active (#${activeJam.weekNumber}, theme: ${activeJam.theme}).`,
+      };
+    }
+
+    if (!Number.isFinite(durationHours) || durationHours < 1) {
+      return {
+        success: false,
+        error: "Duration must be at least 1 hour.",
+      };
+    }
+
+    const jam = await this.createNewJam(guild, durationHours);
+    if (!jam) {
+      return {
+        success: false,
+        error:
+          "Could not create jam. Make sure a jam channel is configured with `/setjamchannel`.",
+      };
+    }
+
+    return { success: true, jam };
+  }
+
+  /**
+   * Submits a game to the current active jam for a guild.
+   * Returns an error string on failure, or the submission on success.
+   *
+   * @param guildId The ID of the guild where the jam is active.
+   * @param userId The ID of the user submitting the game.
+   * @param gameTitle The title of the submitted game.
+   * @param gameUrl The URL of the submitted game.
+   * @param description An optional description of the game.
+   * @returns An object indicating success or failure, and the submission if successful.
+   */
+  async submitGame(
+    guildId: string,
+    userId: string,
+    gameTitle: string,
+    gameUrl: string,
+    description?: string,
+  ): Promise<{
+    success: boolean;
+    error?: string;
+    submission?: JamSubmissionInstance;
+  }> {
+    const jam = await this.getCurrentJam(guildId);
+
+    if (!jam) {
+      return {
+        success: false,
+        error: "There is no active game jam right now. Check back next week!",
+      };
+    }
+
+    const existing = await JamSubmission.findOne({
+      where: { jamId: jam.id, userId },
+    });
+    if (existing) {
+      return {
+        success: false,
+        error:
+          "You've already submitted a game to this jam. Each participant may only submit once.",
+      };
+    }
+
+    try {
+      const submission = await JamSubmission.create({
+        jamId: jam.id,
+        userId,
+        guildId,
+        gameTitle: gameTitle.slice(0, 100),
+        gameUrl,
+        description: description?.slice(0, 500) ?? null,
+        submittedAt: new Date(),
+      });
+
+      return { success: true, submission };
+    } catch {
+      return {
+        success: false,
+        error: "Failed to save your submission. Please try again.",
+      };
+    }
+  }
+
+  /**
+   * Sets the winner of a jam by submission ID.
+   * Returns an error string on failure.
+   * 
+   * @param guildId The ID of the guild where the jam is active.
+   * @param jamId The ID of the jam to set the winner for.
+   * @param submissionId The ID of the submission to declare as the winner.
+   * @returns An object indicating success or failure, and the winning submission if successful.
+   */
+  async setWinner(
+    guildId: string,
+    jamId: number,
+    submissionId: number,
+  ): Promise<{
+    success: boolean;
+    error?: string;
+    submission?: JamSubmissionInstance;
+  }> {
+    const jam = await Jam.findOne({ where: { id: jamId, guildId } });
+    if (!jam) {
+      return { success: false, error: "Jam not found." };
+    }
+
+    const submission = await JamSubmission.findOne({
+      where: { id: submissionId, jamId },
+    });
+    if (!submission) {
+      return {
+        success: false,
+        error: `Submission #${submissionId} not found in this jam.`,
+      };
+    }
+
+    await jam.update({ winnerSubmissionId: submissionId, status: "closed" });
+
+    await this.announceWinner(guildId, jam, submission);
+
+    return { success: true, submission };
+  }
+
+  // ─── Private helpers ──────────────────────────────────────────────────────────
+
+  private async runCheck(): Promise<void> {
+    for (const [, guild] of this.bot.client.guilds.cache) {
+      try {
+        await this.checkGuild(guild);
+      } catch (error) {
+        this.bot.logger.error(
+          `JamManager: error checking guild ${guild.id}:`,
+          error,
+        );
+      }
+    }
+  }
+
+  private async checkGuild(guild: Guild): Promise<void> {
+    // Check if weekly jams are enabled for this guild
+    const settings = this.bot.guildSettings.get(guild.id);
+    if (!settings) return;
+    const jamEnabled = settings.get(Settings.WeeklyJam, false);
+    if (!jamEnabled) return;
+
+    // Close any expired active jams
+    const activeJam = await this.getCurrentJam(guild.id);
+    if (activeJam && new Date() >= activeJam.endDate) {
+      await this.closeJam(guild, activeJam);
+      return;
+    }
+
+    // Post daily prompt if active jam and not yet posted today
+    if (activeJam) {
+      await this.maybePostDailyPrompt(guild, activeJam);
+      return;
+    }
+
+    // Start a new jam if it's time
+    if (this.isSundayNoon()) {
+      const lastJam = await Jam.findOne({
+        where: { guildId: guild.id },
+        order: [["startDate", "DESC"]],
+      });
+      // Guard: don't create a new jam if the last one ended less than 6 days ago
+      if (lastJam) {
+        const daysSinceLast =
+          (Date.now() - lastJam.endDate.getTime()) / (1000 * 60 * 60 * 24);
+        if (daysSinceLast < 6) return;
+      }
+      await this.createNewJam(guild);
+    }
+  }
+
+  private async createNewJam(
+    guild: Guild,
+    durationHours: number = JAM_DURATION_HOURS,
+  ): Promise<JamInstance | null> {
+    const channel = await this.getJamChannel(guild);
+    if (!channel) {
+      this.bot.logger.warn(
+        `JamManager: no jam channel configured for guild ${guild.id}`,
+      );
+      return null;
+    }
+
+    // Determine theme (avoid recently used)
+    const recentJams = await Jam.findAll({
+      where: { guildId: guild.id },
+      order: [["startDate", "DESC"]],
+      limit: JAM_THEMES_AVOID_COUNT,
+    });
+    const usedThemes = recentJams.map((j) => j.theme);
+    const theme = getNextTheme(usedThemes);
+
+    // Determine week number
+    const jamCount = await Jam.count({ where: { guildId: guild.id } });
+    const weekNumber = jamCount + 1;
+
+    const startDate = new Date();
+    const endDate = new Date(
+      startDate.getTime() + durationHours * 60 * 60 * 1000,
+    );
+
+    const jam = await Jam.create({
+      guildId: guild.id,
+      theme,
+      weekNumber,
+      status: "active",
+      startDate,
+      endDate,
+      winnerSubmissionId: null,
+      discordEventId: null,
+      announcementMessageId: null,
+      lastDailyPromptDate: null,
+    });
+
+    // Post announcement
+    const embed = this.buildAnnouncementEmbed(jam);
+    const intro = getRandomJamElement(JAM_ANNOUNCEMENT_INTROS);
+    const message = await channel.send({
+      content: `🐳 **${intro}**`,
+      embeds: [embed],
+    });
+
+    await jam.update({ announcementMessageId: message.id });
+
+    // Try to create a Discord scheduled event
+    try {
+      const event = await guild.scheduledEvents.create({
+        name: `🐳 Mr. Whale's Weekly Jam #${weekNumber}`,
+        description: `Theme: **${theme}**\n\nBuild a microgame inspired by this theme. Submit with \`/jamsubmit\`!`,
+        scheduledStartTime: startDate,
+        scheduledEndTime: endDate,
+        privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
+        entityType: GuildScheduledEventEntityType.External,
+        entityMetadata: { location: `#${(channel as TextChannel).name}` },
+      });
+      await jam.update({ discordEventId: event.id });
+    } catch {
+      // Discord events are optional — don't fail the whole jam
+    }
+
+    this.bot.logger.info(
+      `JamManager: started jam #${weekNumber} in guild ${guild.id} with theme "${theme}"`,
+    );
+
+    return jam;
+  }
+
+  private async maybePostDailyPrompt(
+    guild: Guild,
+    jam: JamInstance,
+  ): Promise<void> {
+    const today = new Date().toISOString().split("T")[0];
+    if (jam.lastDailyPromptDate === today) return;
+
+    // Don't post on the day the jam starts (announcement already covers it)
+    const jamStartDate = jam.startDate.toISOString().split("T")[0];
+    if (today === jamStartDate) return;
+
+    const channel = await this.getJamChannel(guild);
+    if (!channel) return;
+
+    const prompt = getRandomJamElement(DAILY_PROMPTS);
+    const daysLeft = Math.ceil(
+      (jam.endDate.getTime() - Date.now()) / (1000 * 60 * 60 * 24),
+    );
+
+    const embed = new EmbedBuilder()
+      .setColor(0x1a7fd4)
+      .setTitle("🌊 Today's Deep Sea Inspiration")
+      .setDescription(`*"${prompt}"*`)
+      .addFields(
+        { name: "🎯 Current Theme", value: `**${jam.theme}**`, inline: true },
+        {
+          name: "⏳ Days Remaining",
+          value: `${daysLeft} day${daysLeft !== 1 ? "s" : ""}`,
+          inline: true,
+        },
+      )
+      .setFooter({
+        text: `Submit your game with /jamsubmit • Jam #${jam.weekNumber}`,
+      })
+      .setTimestamp();
+
+    await channel.send({ embeds: [embed] });
+    await jam.update({ lastDailyPromptDate: today });
+  }
+
+  private async closeJam(guild: Guild, jam: JamInstance): Promise<void> {
+    await jam.update({ status: "closed" });
+
+    const channel = await this.getJamChannel(guild);
+    if (!channel) return;
+
+    const submissions = await this.getSubmissions(jam.id);
+    const submissionCount = submissions.length;
+
+    const embed = new EmbedBuilder()
+      .setColor(EMBED_COLOR)
+      .setTitle(`Jam #${jam.weekNumber} Has Ended!`)
+      .setDescription(
+        `**Theme: ${jam.theme}**\n\n` +
+          `${getRandomJamElement(JAM_CLOSE_INTROS)}\n\n` +
+          (submissionCount > 0
+            ? `We received **${submissionCount}** submission${
+                submissionCount !== 1 ? "s" : ""
+              }!\n\nUse \`/jamwinner\` to select and announce the winner.`
+            : `No submissions were received for this jam. Perhaps the squid council scared everyone away.`),
+      )
+      .setFooter({ text: "Thanks to all participants!" })
+      .setTimestamp();
+
+    await channel.send({ embeds: [embed] });
+
+    // End the Discord event if it exists
+    if (jam.discordEventId) {
+      try {
+        const event = await guild.scheduledEvents.fetch(jam.discordEventId);
+        if (event) await event.delete();
+      } catch {
+        // Ignore if event already gone
+      }
+    }
+
+    this.bot.logger.info(
+      `JamManager: closed jam #${jam.weekNumber} in guild ${guild.id} with ${submissionCount} submissions`,
+    );
+  }
+
+  private async announceWinner(
+    guildId: string,
+    jam: JamInstance,
+    submission: JamSubmissionInstance,
+  ): Promise<void> {
+    const guild = this.bot.client.guilds.cache.get(guildId);
+    if (!guild) return;
+
+    const channel = await this.getJamChannel(guild);
+    if (!channel) return;
+
+    let winnerTag = `<@${submission.userId}>`;
+    try {
+      const member = await guild.members.fetch(submission.userId);
+      winnerTag = member.toString();
+    } catch {
+      // User may have left
+    }
+
+    const embed = new EmbedBuilder()
+      .setColor(0xf1c40f)
+      .setTitle(`🏆 Jam #${jam.weekNumber} Winner Announced!`)
+      .setDescription(
+        `*"After consulting the ancient whale council..."*\n\n` +
+          `The winner of **${jam.theme}** is... ${winnerTag}! 🎉`,
+      )
+      .addFields(
+        {
+          name: "🎮 Game",
+          value: `[${submission.gameTitle}](${submission.gameUrl})`,
+        },
+        ...(submission.description
+          ? [{ name: "📝 Description", value: submission.description }]
+          : []),
+      )
+      .setFooter({
+        text: `🐋 Congratulations from Mr. Whale and the squid council!`,
+      })
+      .setTimestamp();
+
+    await channel.send({
+      content: `🎊 Congratulations ${winnerTag}!`,
+      embeds: [embed],
+    });
+  }
+
+  /**
+   * Gets the configured jam channel for a guild, falling back to the announcement channel.
+   * If no channel is configured, returns null.
+   *
+   * @param guild The guild to get the jam channel for.
+   * @returns The text channel to use for jam announcements, or null if none is configured.
+   */
+  async getJamChannel(guild: Guild): Promise<GuildTextBasedChannel | null> {
+    const settings = this.bot.guildSettings.get(guild.id);
+
+    if (settings) {
+      const channelId = settings.get<string>(Settings.JamChannel);
+
+      if (channelId) {
+        try {
+          const channel =
+            guild.channels.cache.get(channelId) ??
+            (await guild.channels.fetch(channelId));
+
+          return channel as GuildTextBasedChannel;
+        } catch (error) {
+          // Channel may have been deleted
+        }
+      }
+    }
+    return null;
+  }
+
+  private buildAnnouncementEmbed(jam: JamInstance): EmbedBuilder {
+    return new EmbedBuilder()
+      .setColor(0x3498db)
+      .setTitle(`Weekly Jam #${jam.weekNumber}`)
+      .setDescription(
+        `**🎯 Theme: ${jam.theme}**\n\n` +
+          `Build a microgame (5-8 seconds) inspired by this theme!\n\n` +
+          `**📋 Rules:**\n` +
+          `- Make something short — Warioware-style microgames!\n` +
+          `- Submit using \`/jamsubmit\` before the deadline\n` +
+          `- One submission per person\n\n` +
+          `**🏆 Prizes:**\n` +
+          `- Winner receives the Champion of the Deep role\n` +
+          `- Fame, glory, and whale approval`,
+      )
+      .addFields(
+        {
+          name: "📅 Ends",
+          value: `<t:${Math.floor(jam.endDate.getTime() / 1000)}:F>`,
+          inline: true,
+        },
+        {
+          name: "⏳ Duration",
+          value: `${JAM_DURATION_DAYS} days`,
+          inline: true,
+        },
+      )
+      .setFooter({ text: "Good luck, land dwellers. 🐋" })
+      .setTimestamp();
+  }
+
+  private isSundayNoon(): boolean {
+    const now = new Date();
+    const dayOfWeek = now.getUTCDay();
+    const hourUTC = now.getUTCHours();
+    return dayOfWeek === JAM_START_DAY && hourUTC === JAM_START_HOUR_UTC;
+  }
+}
+
+// Avoid reusing the last N themes
+const JAM_THEMES_AVOID_COUNT = 10;

--- a/packages/mrwhale-discord/src/commands/admin/jam-winner.ts
+++ b/packages/mrwhale-discord/src/commands/admin/jam-winner.ts
@@ -1,0 +1,85 @@
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  Message,
+  PermissionFlagsBits,
+} from "discord.js";
+
+import { DiscordCommand } from "../../client/command/discord-command";
+
+export default class extends DiscordCommand {
+  constructor() {
+    super({
+      name: "jamwinner",
+      description: "Select and announce the winner of the current or most recent jam. (Moderator only)",
+      type: "admin",
+      usage: "<prefix>jamwinner",
+      guildOnly: true,
+      callerPermissions: [PermissionFlagsBits.ManageGuild],
+    });
+    this.slashCommandData
+      .addIntegerOption((o) =>
+        o
+          .setName("submission_id")
+          .setDescription("The submission ID to declare as winner (see /jaminfo for IDs)")
+          .setRequired(true)
+      )
+      .addIntegerOption((o) =>
+        o
+          .setName("jam_id")
+          .setDescription("The jam ID (defaults to current active or last closed jam)")
+          .setRequired(false)
+      );
+    this.slashCommandData.setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild);
+  }
+
+  async action(message: Message): Promise<Message> {
+    return message.reply("Please use the slash command `/jamwinner` to select a winner.");
+  }
+
+  async slashCommandAction(interaction: ChatInputCommandInteraction): Promise<void> {
+    await interaction.deferReply({ ephemeral: true });
+
+    const submissionId = interaction.options.getInteger("submission_id", true);
+    const jamId = interaction.options.getInteger("jam_id") ?? null;
+
+    // Resolve the jam to use
+    let resolvedJamId: number;
+    if (jamId !== null) {
+      resolvedJamId = jamId;
+    } else {
+      const currentJam = await this.botClient.jamManager.getCurrentJam(interaction.guildId!);
+      if (!currentJam) {
+        const pastJams = await this.botClient.jamManager.getPastJams(interaction.guildId!, 1);
+        if (pastJams.length === 0) {
+          await interaction.editReply("❌ No jams found for this server.");
+          return;
+        }
+        resolvedJamId = pastJams[0].id;
+      } else {
+        resolvedJamId = currentJam.id;
+      }
+    }
+
+    const result = await this.botClient.jamManager.setWinner(
+      interaction.guildId!,
+      resolvedJamId,
+      submissionId
+    );
+
+    if (!result.success) {
+      await interaction.editReply(`❌ ${result.error}`);
+      return;
+    }
+
+    const embed = new EmbedBuilder()
+      .setColor(0x2ecc71)
+      .setTitle("✅ Winner Selected!")
+      .setDescription(
+        `**${result.submission!.gameTitle}** by <@${result.submission!.userId}> has been declared the winner!\n\n` +
+        `The winner announcement has been posted in the jam channel.`
+      );
+
+    await interaction.editReply({ embeds: [embed] });
+  }
+}

--- a/packages/mrwhale-discord/src/commands/admin/set-jam-channel.ts
+++ b/packages/mrwhale-discord/src/commands/admin/set-jam-channel.ts
@@ -1,0 +1,72 @@
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  Message,
+  PermissionFlagsBits,
+} from "discord.js";
+
+import { DiscordCommand } from "../../client/command/discord-command";
+import { Settings } from "../../types/settings";
+
+export default class extends DiscordCommand {
+  constructor() {
+    super({
+      name: "setjamchannel",
+      description: "Set the channel used for weekly game jam announcements. (Moderator only)",
+      type: "admin",
+      usage: "<prefix>setjamchannel",
+      guildOnly: true,
+      callerPermissions: [PermissionFlagsBits.ManageGuild],
+    });
+    this.slashCommandData
+      .addChannelOption((o) =>
+        o
+          .setName("channel")
+          .setDescription("The channel to use for jam announcements and daily prompts")
+          .setRequired(true)
+      )
+      .addBooleanOption((o) =>
+        o
+          .setName("enable")
+          .setDescription("Enable or disable weekly jams for this server (default: true)")
+          .setRequired(false)
+      );
+    this.slashCommandData.setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild);
+  }
+
+  async action(message: Message): Promise<Message> {
+    return message.reply("Please use the slash command `/setjamchannel` to configure the jam channel.");
+  }
+
+  async slashCommandAction(interaction: ChatInputCommandInteraction): Promise<void> {
+    await interaction.deferReply({ ephemeral: true });
+
+    const channel = interaction.options.getChannel("channel", true);
+    const enable = interaction.options.getBoolean("enable") ?? true;
+
+    const settings = this.botClient.guildSettings.get(interaction.guildId!);
+    if (!settings) {
+      await interaction.editReply("❌ Guild settings not found. Please try again.");
+      return;
+    }
+
+    settings.set(Settings.JamChannel, channel.id);
+    settings.set(Settings.WeeklyJam, enable);
+
+    const embed = new EmbedBuilder()
+      .setColor(0x2ecc71)
+      .setTitle("✅ Jam Settings Updated")
+      .addFields(
+        { name: "📢 Jam Channel", value: `<#${channel.id}>`, inline: true },
+        { name: "⚙️ Weekly Jams", value: enable ? "✅ Enabled" : "❌ Disabled", inline: true }
+      )
+      .setDescription(
+        enable
+          ? "Weekly jams will auto-start every Sunday at 12:00 UTC. Use `/startjam` any time if you want to test now or recover a missed Sunday."
+          : "Weekly jams have been disabled for this server."
+      )
+      .setTimestamp();
+
+    await interaction.editReply({ embeds: [embed] });
+  }
+}

--- a/packages/mrwhale-discord/src/commands/admin/start-jam.ts
+++ b/packages/mrwhale-discord/src/commands/admin/start-jam.ts
@@ -1,0 +1,88 @@
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  Message,
+  PermissionFlagsBits,
+} from "discord.js";
+
+import { DiscordCommand } from "../../client/command/discord-command";
+
+const DEFAULT_TEST_DURATION_HOURS = 168;
+
+export default class extends DiscordCommand {
+  constructor() {
+    super({
+      name: "startjam",
+      description:
+        "Manually start a weekly game jam now (useful for testing or missed Sundays).",
+      type: "admin",
+      usage: "<prefix>startjam [duration-hours]",
+      guildOnly: true,
+      callerPermissions: [PermissionFlagsBits.ManageGuild],
+    });
+
+    this.slashCommandData
+      .addIntegerOption((option) =>
+        option
+          .setName("duration_hours")
+          .setDescription(
+            "Optional jam duration in hours (default 168 / 7 days, useful for testing)",
+          )
+          .setRequired(false)
+          .setMinValue(1)
+          .setMaxValue(24 * 30),
+      )
+      .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild);
+  }
+
+  async action(message: Message): Promise<Message> {
+    return message.reply(
+      "Please use the slash command `/startjam` (admin only).",
+    );
+  }
+
+  async slashCommandAction(
+    interaction: ChatInputCommandInteraction,
+  ): Promise<void> {
+    await interaction.deferReply({ ephemeral: true });
+
+    const durationHours =
+      interaction.options.getInteger("duration_hours") ??
+      DEFAULT_TEST_DURATION_HOURS;
+
+    const result = await this.botClient.jamManager.createJamNow(
+      interaction.guildId!,
+      durationHours,
+    );
+
+    if (!result.success || !result.jam) {
+      await interaction.editReply(`❌ ${result.error}`);
+      return;
+    }
+
+    const embed = new EmbedBuilder()
+      .setColor(0x2ecc71)
+      .setTitle("✅ Jam Started")
+      .setDescription(
+        `Started **Jam #${result.jam.weekNumber}** with theme **${result.jam.theme}**.`,
+      )
+      .addFields(
+        {
+          name: "⏳ Duration",
+          value: `${durationHours} hour${durationHours === 1 ? "" : "s"}`,
+          inline: true,
+        },
+        {
+          name: "📅 Ends",
+          value: `<t:${Math.floor(result.jam.endDate.getTime() / 1000)}:F>`,
+          inline: true,
+        },
+      )
+      .setFooter({
+        text: "Automatic scheduling still runs on Sundays at 12:00 UTC.",
+      })
+      .setTimestamp();
+
+    await interaction.editReply({ embeds: [embed] });
+  }
+}

--- a/packages/mrwhale-discord/src/commands/game/jam-hall-of-fame.ts
+++ b/packages/mrwhale-discord/src/commands/game/jam-hall-of-fame.ts
@@ -1,0 +1,71 @@
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  Message,
+} from "discord.js";
+
+import { DiscordCommand } from "../../client/command/discord-command";
+import { JamSubmission } from "../../database/models/jam-submission";
+
+export default class extends DiscordCommand {
+  constructor() {
+    super({
+      name: "jamhalloffame",
+      description: "View the Hall of Fame for past weekly game jam winners.",
+      type: "game",
+      usage: "<prefix>jamhalloffame",
+      aliases: ["jamhof", "jamwinners"],
+      guildOnly: true,
+    });
+  }
+
+  async action(message: Message): Promise<Message> {
+    const response = await this.buildResponse(message.guildId!);
+    return message.reply(response);
+  }
+
+  async slashCommandAction(interaction: ChatInputCommandInteraction): Promise<void> {
+    await interaction.deferReply();
+    const response = await this.buildResponse(interaction.guildId!);
+    await interaction.editReply(response);
+  }
+
+  private async buildResponse(guildId: string) {
+    const pastJams = await this.botClient.jamManager.getPastJams(guildId, 10);
+    const closedWithWinner = pastJams.filter((j) => j.winnerSubmissionId !== null);
+
+    if (closedWithWinner.length === 0) {
+      return {
+        embeds: [
+          new EmbedBuilder()
+            .setColor(0x95a5a6)
+            .setTitle("🏆 Hall of Fame")
+            .setDescription("No winners have been crowned yet. Stay tuned!")
+            .setTimestamp(),
+        ],
+      };
+    }
+
+    // Fetch winner submissions in bulk
+    const winnerIds = closedWithWinner.map((j) => j.winnerSubmissionId!);
+    const winnerSubmissions = await JamSubmission.findAll({
+      where: { id: winnerIds },
+    });
+    const submissionMap = new Map(winnerSubmissions.map((s) => [s.id, s]));
+
+    const lines = closedWithWinner.map((jam) => {
+      const sub = submissionMap.get(jam.winnerSubmissionId!);
+      if (!sub) return `**Jam #${jam.weekNumber}** — *${jam.theme}* — No winner recorded`;
+      return `**Jam #${jam.weekNumber}** — *${jam.theme}*\n🏆 [${sub.gameTitle}](${sub.gameUrl}) by <@${sub.userId}>`;
+    });
+
+    const embed = new EmbedBuilder()
+      .setColor(0xf1c40f)
+      .setTitle("🏆 Mr. Whale's Hall of Fame")
+      .setDescription(lines.join("\n\n"))
+      .setFooter({ text: "Honoured by the squid council 🦑" })
+      .setTimestamp();
+
+    return { embeds: [embed] };
+  }
+}

--- a/packages/mrwhale-discord/src/commands/game/jam-info.ts
+++ b/packages/mrwhale-discord/src/commands/game/jam-info.ts
@@ -1,0 +1,97 @@
+import { ChatInputCommandInteraction, EmbedBuilder, Message } from "discord.js";
+
+import { DiscordCommand } from "../../client/command/discord-command";
+import { EMBED_COLOR } from "../../constants";
+
+export default class extends DiscordCommand {
+  constructor() {
+    super({
+      name: "jaminfo",
+      description: "View the current weekly game jam and its submissions.",
+      type: "game",
+      usage: "<prefix>jaminfo",
+      guildOnly: true,
+    });
+  }
+
+  async action(message: Message): Promise<Message> {
+    const response = await this.buildResponse(message.guildId!);
+    return message.reply(response);
+  }
+
+  async slashCommandAction(
+    interaction: ChatInputCommandInteraction,
+  ): Promise<void> {
+    await interaction.deferReply();
+    const response = await this.buildResponse(interaction.guildId!);
+    await interaction.editReply(response);
+  }
+
+  private async buildResponse(guildId: string) {
+    const jam = await this.botClient.jamManager.getCurrentJam(guildId);
+
+    if (!jam) {
+      return {
+        embeds: [
+          new EmbedBuilder()
+            .setColor(0x95a5a6)
+            .setTitle("No Active Game Jam")
+            .setDescription(
+              "There is no game jam running right now.\n\n" +
+                "Automatic jams start every Sunday at 12:00 UTC.\n" +
+                "A moderator can configure jams with `/setjamchannel` and start one immediately with `/startjam`.",
+            )
+            .setTimestamp(),
+        ],
+      };
+    }
+
+    const submissions = await this.botClient.jamManager.getSubmissions(jam.id);
+    const daysLeft = Math.max(
+      0,
+      Math.ceil((jam.endDate.getTime() - Date.now()) / (1000 * 60 * 60 * 24)),
+    );
+
+    const embed = new EmbedBuilder()
+      .setColor(EMBED_COLOR)
+      .setTitle(`Weekly Jam #${jam.weekNumber}`)
+      .setDescription(`**🎯 Theme: ${jam.theme}**`)
+      .addFields(
+        {
+          name: "⏳ Ends",
+          value: `<t:${Math.floor(
+            jam.endDate.getTime() / 1000,
+          )}:R> (<t:${Math.floor(jam.endDate.getTime() / 1000)}:F>)`,
+        },
+        {
+          name: "📊 Submissions",
+          value:
+            submissions.length > 0
+              ? submissions
+                  .slice(0, 10)
+                  .map(
+                    (s, i) =>
+                      `${i + 1}. **[${s.gameTitle}](${s.gameUrl})** by <@${
+                        s.userId
+                      }>`,
+                  )
+                  .join("\n") +
+                (submissions.length > 10
+                  ? `\n*...and ${submissions.length - 10} more*`
+                  : "")
+              : "No submissions yet — be the first! Use `/jamsubmit`",
+        },
+      )
+      .setFooter({
+        text:
+          daysLeft > 0
+            ? `${daysLeft} day${
+                daysLeft !== 1 ? "s" : ""
+              } remaining • Submit with /jamsubmit`
+            : "Submissions have closed",
+      })
+      .setTimestamp();
+
+    return { embeds: [embed] };
+  }
+}

--- a/packages/mrwhale-discord/src/commands/game/jam-submit.ts
+++ b/packages/mrwhale-discord/src/commands/game/jam-submit.ts
@@ -1,0 +1,78 @@
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  Message,
+} from "discord.js";
+
+import { DiscordCommand } from "../../client/command/discord-command";
+
+export default class extends DiscordCommand {
+  constructor() {
+    super({
+      name: "jamsubmit",
+      description: "Submit your microgame to the current weekly jam.",
+      type: "game",
+      usage: "<prefix>jamsubmit",
+      guildOnly: true,
+    });
+    this.slashCommandData
+      .addStringOption((o) =>
+        o.setName("title").setDescription("The title of your game").setRequired(true).setMaxLength(100)
+      )
+      .addStringOption((o) =>
+        o.setName("url").setDescription("Link to play or download your game").setRequired(true)
+      )
+      .addStringOption((o) =>
+        o.setName("description").setDescription("Short description of your game (optional)").setRequired(false).setMaxLength(500)
+      );
+  }
+
+  async action(message: Message): Promise<Message> {
+    return message.reply("Please use the slash command `/jamsubmit` to submit your game.");
+  }
+
+  async slashCommandAction(interaction: ChatInputCommandInteraction): Promise<void> {
+    await interaction.deferReply({ ephemeral: true });
+
+    const title = interaction.options.getString("title", true);
+    const url = interaction.options.getString("url", true);
+    const description = interaction.options.getString("description") ?? undefined;
+
+    // Basic URL validation
+    try {
+      new URL(url);
+    } catch {
+      await interaction.editReply("❌ Please provide a valid URL for your game.");
+      return;
+    }
+
+    const result = await this.botClient.jamManager.submitGame(
+      interaction.guildId!,
+      interaction.user.id,
+      title,
+      url,
+      description
+    );
+
+    if (!result.success) {
+      await interaction.editReply(`❌ ${result.error}`);
+      return;
+    }
+
+    const jam = await this.botClient.jamManager.getCurrentJam(interaction.guildId!);
+
+    const embed = new EmbedBuilder()
+      .setColor(0x2ecc71)
+      .setTitle("✅ Game Submitted!")
+      .setDescription(`Your game has been entered into **Jam #${jam!.weekNumber}: ${jam!.theme}**!`)
+      .addFields(
+        { name: "🎮 Game Title", value: title },
+        { name: "🔗 Link", value: url },
+        ...(description ? [{ name: "📝 Description", value: description }] : [])
+      )
+      .setFooter({ text: "Good luck! 🐋 The squid council is watching." })
+      .setTimestamp();
+
+    await interaction.editReply({ embeds: [embed] });
+  }
+}

--- a/packages/mrwhale-discord/src/data/jam-data.ts
+++ b/packages/mrwhale-discord/src/data/jam-data.ts
@@ -1,0 +1,134 @@
+/**
+ * Weekly jam themes for Mr. Whale's Game Jam.
+ */
+export const JAM_THEMES: string[] = [
+  "One Button",
+  "Don't Blink",
+  "Hidden",
+  "Tiny Disaster",
+  "Too Fast",
+  "Exploding Sandwich",
+  "Tentacles",
+  "Reverse Controls",
+  "Panic",
+  "Wrong Button",
+  "Upside Down",
+  "Don't Stop",
+  "Gravity Is Broken",
+  "The Floor Is Lava",
+  "Impossible",
+  "Backwards",
+  "Eyes Closed",
+  "On Fire",
+  "Shrinking",
+  "Overloaded",
+  "Underwater",
+  "Glitch",
+  "Last Stand",
+  "Forbidden",
+  "Chaos",
+  "Tiny",
+  "Haunted",
+  "Lost",
+  "Speed Run",
+  "Don't Lose It",
+  "Multiplied",
+  "Invisible",
+  "Fragile",
+  "Darkness",
+  "Time Loop",
+  "Out of Control",
+  "The Wrong Way",
+  "Reflection",
+  "Echo",
+  "Void",
+];
+
+/**
+ * Daily inspiration prompts for non-jam days.
+ */
+export const DAILY_PROMPTS: string[] = [
+  "What if the main character was also the obstacle?",
+  "A game where winning feels wrong.",
+  "Your weapon is also your shield.",
+  "The world shrinks every second.",
+  "The enemy wants to be your friend.",
+  "You can only move in one direction.",
+  "The game ends when you get bored.",
+  "Every mistake makes you stronger.",
+  "You are playing as the boss.",
+  "The final boss is the loading screen.",
+  "The game plays itself, but better.",
+  "Everything is made of sandwiches.",
+  "You can only see what you've already seen.",
+  "The map is wrong on purpose.",
+  "Death is the win condition.",
+  "The music is a hint.",
+  "You cannot jump. You can only fall upwards.",
+  "The score decreases when you do well.",
+  "The game lies to you constantly.",
+  "There are two players. You control both.",
+  "The enemy is your reflection.",
+  "The level is inside a fish.",
+  "You have infinite lives but limited time.",
+];
+
+/**
+ * Mr. Whale's intro messages for weekly jam announcements.
+ * Used to give the bot personality.
+ */
+export const JAM_ANNOUNCEMENT_INTROS: string[] = [
+  "After a lengthy debate with the squid council... I have decided to announce this week's jam!",
+  "While exploring the deepest trench in the ocean... I found a mysterious message in a bottle that inspired this week's jam!",
+  "After accidentally swallowing a submarine... I had a vision of this week's jam theme!",
+  "Following a surprisingly heated argument with a jellyfish... I have decided on this week's jam theme!",
+  "After consulting the ancient whale oracle... I have received guidance for this week's jam theme!",
+  "I accidentally awakened an ancient sea creature, and it had ideas for this week's jam theme...",
+  "After three days lost in a kelp forest... I emerged with a new jam theme!",
+  "While napping on the ocean floor, I had a vision... This week's jam theme is clear!",
+  "The plankton have voted, and they demand... This week's jam theme!",
+
+  "After escaping a particularly aggressive dolphin... I have decided on this week's jam theme!",
+  "I found a message in a bottle at the bottom of the ocean... It revealed this week's jam theme!",
+  "The squid king insists this is a good idea... This week's jam theme is approved!",
+  "After a spirited debate with a very opinionated crab... We have settled on this week's jam theme!",
+  "While breaching for dramatic effect... I realized this week's jam theme!",
+  "The tide has spoken, and its words were... This week's jam theme!",
+];
+
+/**
+ * Mr. Whale's closing messages when a jam ends.
+ */
+export const JAM_CLOSE_INTROS: string[] = [
+  "After reviewing all entries with the squid council...",
+  "After extensive deliberation in the deep...",
+  "The ancient whale tribunal has reached a verdict...",
+  "After consulting the ocean floor archives...",
+  "The tide has decided...",
+];
+
+/**
+ * Roles that can be awarded to jam winners.
+ */
+export const JAM_WINNER_ROLES = {
+  champion: "🐋 Champion of the Deep",
+  explorer: "🦑 Abyss Explorer",
+  survivor: "🦑 Squid Survivor",
+  master: "🎮 Microgame Master",
+} as const;
+
+/**
+ * Returns a random element from an array.
+ */
+export function getRandomJamElement<T>(array: T[]): T {
+  return array[Math.floor(Math.random() * array.length)];
+}
+
+/**
+ * Returns a theme that hasn't been used recently, falling back to random if all have been used.
+ */
+export function getNextTheme(usedThemes: string[] = []): string {
+  const available = JAM_THEMES.filter((t) => !usedThemes.includes(t));
+  const pool = available.length > 0 ? available : JAM_THEMES;
+  return getRandomJamElement(pool);
+}

--- a/packages/mrwhale-discord/src/database/models/jam-submission.ts
+++ b/packages/mrwhale-discord/src/database/models/jam-submission.ts
@@ -1,0 +1,78 @@
+import { Model, DataTypes } from "sequelize";
+import { database } from "..";
+
+interface JamSubmissionAttributes {
+  id: number;
+  jamId: number;
+  userId: string;
+  guildId: string;
+  gameTitle: string;
+  gameUrl: string;
+  description: string | null;
+  submittedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface JamSubmissionInstance
+  extends Model<JamSubmissionAttributes, Partial<JamSubmissionAttributes>>,
+    JamSubmissionAttributes {}
+
+export const JamSubmission = database.connection.define<JamSubmissionInstance>(
+  "JamSubmission",
+  {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: DataTypes.INTEGER,
+    },
+    jamId: {
+      allowNull: false,
+      type: DataTypes.INTEGER,
+      references: { model: "jams", key: "id" },
+    },
+    userId: {
+      allowNull: false,
+      type: DataTypes.STRING,
+    },
+    guildId: {
+      allowNull: false,
+      type: DataTypes.STRING,
+    },
+    gameTitle: {
+      allowNull: false,
+      type: DataTypes.STRING,
+    },
+    gameUrl: {
+      allowNull: false,
+      type: DataTypes.STRING,
+    },
+    description: {
+      allowNull: true,
+      type: DataTypes.TEXT,
+    },
+    submittedAt: {
+      allowNull: false,
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+    },
+    createdAt: {
+      allowNull: false,
+      type: DataTypes.DATE,
+    },
+    updatedAt: {
+      allowNull: false,
+      type: DataTypes.DATE,
+    },
+  },
+  {
+    tableName: "jam_submissions",
+    timestamps: true,
+    indexes: [
+      { fields: ["jamId"] },
+      { fields: ["userId", "guildId"] },
+      { unique: true, fields: ["jamId", "userId"], name: "unique_submission_per_user_per_jam" },
+    ],
+  }
+);

--- a/packages/mrwhale-discord/src/database/models/jam.ts
+++ b/packages/mrwhale-discord/src/database/models/jam.ts
@@ -1,0 +1,91 @@
+import { Model, DataTypes } from "sequelize";
+import { database } from "..";
+
+export type JamStatus = "active" | "closed" | "cancelled";
+
+interface JamAttributes {
+  id: number;
+  guildId: string;
+  theme: string;
+  weekNumber: number;
+  status: JamStatus;
+  startDate: Date;
+  endDate: Date;
+  winnerSubmissionId: number | null;
+  discordEventId: string | null;
+  announcementMessageId: string | null;
+  lastDailyPromptDate: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface JamInstance
+  extends Model<JamAttributes, Partial<JamAttributes>>,
+    JamAttributes {}
+
+export const Jam = database.connection.define<JamInstance>(
+  "Jam",
+  {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: DataTypes.INTEGER,
+    },
+    guildId: {
+      allowNull: false,
+      type: DataTypes.STRING,
+    },
+    theme: {
+      allowNull: false,
+      type: DataTypes.STRING,
+    },
+    weekNumber: {
+      allowNull: false,
+      type: DataTypes.INTEGER,
+    },
+    status: {
+      allowNull: false,
+      type: DataTypes.STRING,
+      defaultValue: "active",
+    },
+    startDate: {
+      allowNull: false,
+      type: DataTypes.DATE,
+    },
+    endDate: {
+      allowNull: false,
+      type: DataTypes.DATE,
+    },
+    winnerSubmissionId: {
+      allowNull: true,
+      type: DataTypes.INTEGER,
+    },
+    discordEventId: {
+      allowNull: true,
+      type: DataTypes.STRING,
+    },
+    announcementMessageId: {
+      allowNull: true,
+      type: DataTypes.STRING,
+    },
+    lastDailyPromptDate: {
+      allowNull: true,
+      type: DataTypes.STRING,
+      comment: "Date in YYYY-MM-DD format of the last daily prompt posted",
+    },
+    createdAt: {
+      allowNull: false,
+      type: DataTypes.DATE,
+    },
+    updatedAt: {
+      allowNull: false,
+      type: DataTypes.DATE,
+    },
+  },
+  {
+    tableName: "jams",
+    timestamps: true,
+    indexes: [{ fields: ["guildId"] }, { fields: ["status"] }],
+  },
+);

--- a/packages/mrwhale-discord/src/types/settings.ts
+++ b/packages/mrwhale-discord/src/types/settings.ts
@@ -13,4 +13,6 @@ export enum Settings {
   LevelChannel = "levelChannel",
   Prefix = "prefix",
   RankCard = "rankCard",
+  JamChannel = "jamChannel",
+  WeeklyJam = "weeklyJam",
 }


### PR DESCRIPTION
This pull request introduces a comprehensive weekly game jam system to the Discord bot, enabling servers to host, manage, and participate in recurring game jams. The changes add new commands for both users and moderators, a jam manager, and supporting data for themes and prompts. The most important changes are grouped below by theme.

**Game Jam Core Functionality:**

* Added a new `JamManager` to the bot client, responsible for handling all jam-related operations, including scheduling, submissions, and winner selection. (`discord-bot-client.ts` updates)
* Introduced `jam-data.ts` containing weekly jam themes, daily prompts, announcement intros, and utility functions for random selection and theme rotation.

**User Commands:**

* Added `/jaminfo` to display the current jam and its submissions, `/jamsubmit` for users to submit their games, and `/jamhalloffame` to showcase past jam winners.

**Admin/Moderator Commands:**

* Added `/setjamchannel` to configure the jam announcement channel and enable/disable jams, `/startjam` to manually start a jam, and `/jamwinner` to select and announce a winner for a jam.

These changes together provide a full-featured, automated game jam experience for Discord communities.